### PR TITLE
Update to retrieval api and format to markdown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 chromadb>=0.3.11
-langchain>=0.0.115
+langchain>=0.0.123
 openai>=0.27.2
 flask>=2.2.3
 sentencepiece>=0.1.97

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(root / "requirements.txt") as f:
 
 setup(
     name="spikeinterface-chatbot",
-    version="0.0.1",
+    version="0.0.2",
     description="A chatbot for spikeinterface",
     packages=find_packages(where="src"),
     package_dir={"": "src"},

--- a/src/spikeinterface_chatbot/app.py
+++ b/src/spikeinterface_chatbot/app.py
@@ -7,15 +7,17 @@ from spikeinterface_chatbot.lang_chain_machinery import query_documentation
 app = Flask(__name__)
 
 
-@app.route("/", methods=["GET", "POST"])
+@app.route("/process_message", methods=["POST"])
+def process_message():
+    message = request.form["message"]
+    persist_directory = "./data/chroma_database"
+    response = query_documentation(query=message, persist_directory=persist_directory)
+    return response
+
+
+@app.route("/", methods=["GET"])
 def chat():
-    if request.method == "POST":
-        message = request.form["message"]
-        persist_directory = "./data/chroma_database"
-        response = query_documentation(query=message, persist_directory=persist_directory)
-        return response
-    else:
-        return render_template("chat.html")
+    return render_template("chat.html")
 
 
 if __name__ == "__main__":

--- a/src/spikeinterface_chatbot/static/chat.js
+++ b/src/spikeinterface_chatbot/static/chat.js
@@ -1,31 +1,24 @@
 const chatHistory = document.querySelector('#chat-history');
-const form = document.querySelector('#chat-form');
+const form = document.querySelector('form');
+const converter = new showdown.Converter();
 
 form.addEventListener('submit', event => {
     event.preventDefault();
-
     const message = document.querySelector('input[name="message"]').value;
-    chatHistory.innerHTML += `
-        <div class="message user-message">
-            <p><strong>Question:</strong> ${message}</p>
-        </div>
-    `;
+    chatHistory.innerHTML += `<div class="message user-message"><p><strong>Question:</strong> ${message}</p></div>`;
 
-    fetch('/process_message', { // Update this route to match your Flask route
+    fetch('/process_message', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/x-www-form-urlencoded'
         },
         body: new URLSearchParams(new FormData(form))
     })
-    .then(response => response.text())
-    .then(data => {
-        chatHistory.innerHTML += `
-            <div class="message bot-message">
-                <p><strong>Answer:</strong> ${data}</p>
-            </div>
-        `;
-        form.reset();
-        chatHistory.scrollTop = chatHistory.scrollHeight;
-    });
+        .then(response => response.text())
+        .then(data => {
+            const botHtmlResponse = converter.makeHtml(data);
+            chatHistory.innerHTML += `<div class="message bot-message"><p><strong>Answer:</strong></p>${botHtmlResponse}</div>`;
+            form.reset();
+            chatHistory.scrollTop = chatHistory.scrollHeight;
+        });
 });

--- a/src/spikeinterface_chatbot/static/chat.js
+++ b/src/spikeinterface_chatbot/static/chat.js
@@ -1,0 +1,31 @@
+const chatHistory = document.querySelector('#chat-history');
+const form = document.querySelector('#chat-form');
+
+form.addEventListener('submit', event => {
+    event.preventDefault();
+
+    const message = document.querySelector('input[name="message"]').value;
+    chatHistory.innerHTML += `
+        <div class="message user-message">
+            <p><strong>Question:</strong> ${message}</p>
+        </div>
+    `;
+
+    fetch('/process_message', { // Update this route to match your Flask route
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: new URLSearchParams(new FormData(form))
+    })
+    .then(response => response.text())
+    .then(data => {
+        chatHistory.innerHTML += `
+            <div class="message bot-message">
+                <p><strong>Answer:</strong> ${data}</p>
+            </div>
+        `;
+        form.reset();
+        chatHistory.scrollTop = chatHistory.scrollHeight;
+    });
+});

--- a/src/spikeinterface_chatbot/templates/chat.html
+++ b/src/spikeinterface_chatbot/templates/chat.html
@@ -28,13 +28,13 @@
             border-radius: 10px;
             box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
             margin: 20px auto;
-            max-width: 600px;
+            max-width: 800px;
             padding: 20px;
             background-color: #fff;
         }
 
         #chat-history {
-            height: 400px;
+            height: 700px;
             overflow-y: scroll;
             margin-bottom: 20px;
             padding: 5px;
@@ -57,10 +57,10 @@
 
         /* Bot message */
         .bot-message {
-            background-color: #e2ffe2;
+            background-color: #ffffff;
             color: #555;
             align-self: flex-start;
-            margin-right: 40%;
+            margin-right: 20%;
         }
 
         /* Chat input form */
@@ -95,6 +95,21 @@
 
         input[type="submit"]:hover {
             background-color: #3e4f7c;
+        }
+
+        /* Markdown styles */
+        pre {
+            background-color: #f5f5f5;
+            border: 1px solid #ccc;
+            border-radius: 5px;
+            padding: 10px;
+            overflow-x: auto;
+            white-space: pre-wrap;
+        }
+
+        code {
+            font-family: 'Consolas', 'Courier New', monospace;
+            font-size: 14px;
         }
     </style>
 </head>

--- a/src/spikeinterface_chatbot/templates/chat.html
+++ b/src/spikeinterface_chatbot/templates/chat.html
@@ -1,12 +1,16 @@
 <!DOCTYPE html>
 <html>
+<head>
+    <!-- Other head elements -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.9.1/showdown.min.js"></script>
+</head>
 
 <head>
     <title>Spikeinterface chat</title>
     <style>
         /* Global styles */
         body {
-            font-family: Arial, sans-serif;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
             margin: 0;
             padding: 0;
             background-color: #f5f5f5;
@@ -20,9 +24,9 @@
         }
 
         #chat {
-            border: 1px solid #ccc;
-            border-radius: 5px;
-            box-shadow: 0 0 10px #ccc;
+            border: none;
+            border-radius: 10px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
             margin: 20px auto;
             max-width: 600px;
             padding: 20px;
@@ -33,12 +37,12 @@
             height: 400px;
             overflow-y: scroll;
             margin-bottom: 20px;
+            padding: 5px;
         }
 
         /* Chat message */
         .message {
-            border: 1px solid #ccc;
-            border-radius: 5px;
+            border-radius: 10px;
             margin-bottom: 10px;
             padding: 10px;
         }
@@ -47,12 +51,16 @@
         .user-message {
             background-color: #f1f1f1;
             color: #555;
+            align-self: flex-end;
+            margin-left: 40%;
         }
 
         /* Bot message */
         .bot-message {
             background-color: #e2ffe2;
             color: #555;
+            align-self: flex-start;
+            margin-right: 40%;
         }
 
         /* Chat input form */
@@ -69,6 +77,7 @@
             border: none;
             background-color: #f5f5f5;
             color: #555;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
         }
 
         input[type="submit"] {
@@ -80,6 +89,7 @@
             font-size: 16px;
             margin-left: 10px;
             padding: 10px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
             transition: background-color 0.3s ease-in-out;
         }
 
@@ -93,10 +103,12 @@
     <div id="chat">
         <h1>Spikeinterface chat</h1>
         <div id="chat-history"></div>
-        <form method="POST"> <input type="text" name="message" placeholder="Type your message here..."> <input
-                type="submit" value="Send"> </form>
+        <form id="chat-form" method="POST">
+            <input type="text" name="message" placeholder="Type your message here...">
+            <input type="submit" value="Send">
+        </form>
     </div>
-    <script> const chatHistory = document.querySelector('#chat-history'); const form = document.querySelector('form'); form.addEventListener('submit', event => { event.preventDefault(); const message = document.querySelector('input[name="message"]').value; chatHistory.innerHTML += ` <div class="message user-message"> <p><strong>Question:</strong> ${message}</p> </div> `; fetch('/', { method: 'POST', body: new FormData(form) }).then(response => response.text()).then(data => { chatHistory.innerHTML += ` <div class="message bot-message"> <p><strong>Answer:</strong> ${data}</p> </div> `; form.reset(); chatHistory.scrollTop = chatHistory.scrollHeight; }); }); </script>
+    <script src="{{ url_for('static', filename='chat.js') }}"></script>
 </body>
 
 </html>


### PR DESCRIPTION
This PR contains some updates:
* Uses a specific prompt for prompt engineering which also requests output in markdown. This can be easily changed for experimentation (see the `create_prompt` function)
* Updates the code to the new Retrieval API (see the new use of `RetrievalQA` instead of `VectorDBQA`). The next steps will be to integrate with pinecode and test the new[ plug-in capabilities](https://github.com/openai/chatgpt-retrieval-plugin) locally hoping that we get access : D.
* Separates the javascript code from the html (see the new `chat.js` file).
* Add markdown to HTML display in the javascript code.
* Some changes in styling.