### PR TITLE
Use qdrant as a vectorstore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 /data/*
 /bin/*
+/qdrant_storage/

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Where the -d is the detach command (so you get back your terminal) and the -p is
 Note that for running the docker container locally you will need to pass your OpenAI key as an environment variable:
 
 ```bash
-docker run -p 5000:80 --env OPENAI_API_KEY=your_key_goes_here
+docker run -d -p 5000:80 -e OPENAI_API_KEY=your_key_goes_here -e QDRANT_API_KEY=your_quadrant_api_key_goes_here spikeinterface_chatbot_container
 ```
 
 ### How to push a docker container to github register container

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-chromadb>=0.3.11
 langchain>=0.0.123
 openai>=0.27.2
 flask>=2.2.3
 sentencepiece>=0.1.97
 beautifulsoup4>=4.11.2
+qdrant-client>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(root / "requirements.txt") as f:
 
 setup(
     name="spikeinterface-chatbot",
-    version="0.0.2",
+    version="0.0.3",
     description="A chatbot for spikeinterface",
     packages=find_packages(where="src"),
     package_dir={"": "src"},

--- a/src/spikeinterface_chatbot/database_services.py
+++ b/src/spikeinterface_chatbot/database_services.py
@@ -1,0 +1,135 @@
+from pathlib import Path
+from typing import Optional, List
+import os
+
+from langchain.embeddings.openai import OpenAIEmbeddings
+from langchain.schema import Document
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.document_loaders import DirectoryLoader
+from langchain.vectorstores import Qdrant
+
+
+def retrieve_qdrant_database(
+    port: Optional[int] = 6333, collection_name: Optional[str] = "spikeinterface_documentation"
+) -> Qdrant:
+    """
+    Retrieve a Qdrant database by connecting to the Qdrant instance and returning an initialized Qdrant object.
+
+    Parameters
+    ----------
+    port : Optional[int], default=6333
+        The port to use when connecting to the Qdrant instance.
+    collection_name : Optional[str], default="spikeinterface_documentation"
+        The name of the Qdrant collection to retrieve.
+
+    Returns
+    -------
+    Qdrant
+        An initialized Qdrant object connected to the specified collection.
+    """
+    import qdrant_client
+    from qdrant_client.http.models import CollectionStatus
+
+    url = "https://443e1d88-95ec-48b6-b66d-b5c4713ede35.us-east-1-0.aws.cloud.qdrant.io"
+    api_key = os.environ["QDRANT_API_KEY"]
+    client = qdrant_client.QdrantClient(url=url, api_key=api_key, port=port)
+    collection_info = client.get_collection(collection_name=collection_name)
+    assert collection_info.status == CollectionStatus.GREEN
+
+    embedding_function = OpenAIEmbeddings().embed_query
+    qdrant = Qdrant(client=client, embedding_function=embedding_function, collection_name=collection_name)
+
+    return qdrant
+
+
+def generate_qdrant_database_from_docs(
+    documents: List[Document],
+    port: Optional[int] = 6333,
+    collection_name: Optional[str] = "spikeinterface_documentation",
+) -> Qdrant:
+    """
+    Generate a Qdrant database from a list of documents and return an initialized Qdrant object.
+
+    Parameters
+    ----------
+    documents : List[Document]
+        The list of documents to generate the Qdrant database from.
+    port : Optional[int], default=6333
+        The port to use when connecting to the Qdrant instance.
+    collection_name : Optional[str], default="spikeinterface_documentation"
+        The name of the Qdrant collection to create and use.
+
+    Returns
+    -------
+    Qdrant
+        An initialized Qdrant object connected to the specified collection.
+    """
+    from langchain.vectorstores import Qdrant
+
+    api_key = os.environ["QDRANT_API_KEY"]
+    port = 6333
+    url = "https://443e1d88-95ec-48b6-b66d-b5c4713ede35.us-east-1-0.aws.cloud.qdrant.io:6333"
+
+    texts = [d.page_content for d in documents]
+    metadatas = [d.metadata for d in documents]
+
+    embeddings = OpenAIEmbeddings()
+    collection_name = "spikeinterface_documentation"
+    qdrant = Qdrant.from_texts(
+        texts=texts,
+        embedding=embeddings,
+        metadatas=metadatas,
+        url=url,
+        api_key=api_key,
+        port=port,
+        collection_name=collection_name,
+    )
+
+    return qdrant
+
+
+def generate_croma_database_from_docs(documents: List[Document], persist_directory: str) -> None:
+    """
+    Auxiliary function to generate the croma database (vectorstore).
+
+    Parameters
+    ----------
+    read_the_docs_path : str
+        The paths with the read the docs documentation in html
+    persist_directory : str
+        The directory where the vectorstore database is located.
+
+    """
+    from langchain.vectorstores import Chroma
+
+    embedings = OpenAIEmbeddings()
+    chroma_vectorstore = Chroma.from_documents(documents, embedding=embedings, persist_directory=persist_directory)
+    chroma_vectorstore.persist()
+    chroma_vectorstore = None  # This triggers persistency
+
+
+def generate_documents_from_local_read_the_docs(read_the_docs_path: str) -> Document:
+    """
+    Generate a list of Document objects from a local Read the Docs directory containing HTML files.
+
+    Parameters
+    ----------
+    read_the_docs_path : str
+        The path to the Read the Docs documentation directory containing HTML files.
+
+    Returns
+    -------
+    Document
+        A list of Document objects generated from the local Read the Docs directory.
+    """
+
+    read_the_docs_path = Path(read_the_docs_path)
+    assert read_the_docs_path.exists() and read_the_docs_path.is_dir()
+
+    loader = DirectoryLoader(read_the_docs_path, glob="**/*.html")
+    loaded_documents = loader.load()
+    documents = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=0).split_documents(
+        documents=loaded_documents
+    )
+
+    return documents


### PR DESCRIPTION
This PR updates the vectordatabase to use qdrant instead of the local croma that we were using before.

